### PR TITLE
Use re.MULTILINE for test pattern (#4)

### DIFF
--- a/relint.py
+++ b/relint.py
@@ -53,7 +53,7 @@ def load_config(path):
                 filename = list(filename)
             yield Test(
                 name=test['name'],
-                pattern=re.compile(test['pattern']),
+                pattern=re.compile(test['pattern'], re.MULTILINE),
                 hint=test.get('hint'),
                 filename=filename,
                 error=test.get('error', True)


### PR DESCRIPTION
As a result, in a pattern ^ and $ are now matching start and end
of the line, not just start and end of the string.

Supposed to fix #4