### PR TITLE
Escape filenames which looks like regexp

### DIFF
--- a/relint.py
+++ b/relint.py
@@ -188,7 +188,7 @@ def main():
     paths = {
         path
         for file in args.files
-        for path in glob.iglob(file, recursive=True)
+        for path in glob.iglob(glob.escape(file), recursive=True)
     }
 
     tests = list(load_config(args.config))

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ setup_requires =
 tests_require =
     pytest
     pytest-cov
+    pytest-mock
 py_modules = relint
 
 [options.entry_points]

--- a/test_relint.py
+++ b/test_relint.py
@@ -8,8 +8,9 @@ from relint import (main, match_with_diff_changes, parse_diff, parse_filenames,
 
 
 class TestMain:
-    def test_main_execution(self, mocker):
-        mocker.patch.object(sys, 'argv', ['relint.py', 'test_relint.py'])
+    @pytest.mark.parametrize('filename', ['test_relint.py', '[a-b].py', '[b-a].py'])
+    def test_main_execution(self, mocker, filename):
+        mocker.patch.object(sys, 'argv', ['relint.py', filename])
 
         with pytest.raises(SystemExit) as exc_info:
             main()


### PR DESCRIPTION
Hi, we have issue with files containing square braces in name. `glob` is reading them as regular expressions and crashes when expression is invalid. Filename like `relint "foo[a-b].yml"` is fine and `relint "foo[b-a].yml"` is crashing. To fix this filenames has to be escaped: https://docs.python.org/3/library/glob.html#glob.escape

When implementing fix, I had to improve tests a bit. First change is proper patching of `sys.argv` and `sys.stdin` so tests does not have side effects on other tests.

And second change is rewrite of `test_main_execution_with_diff` to be reliable and doesn't break on changes in `test_relint.py`.