### PR TITLE
Fix #12 -- Remove exec name from pargparse

### DIFF
--- a/relint.py
+++ b/relint.py
@@ -209,7 +209,7 @@ def parse_diff(output):
     return changed_content
 
 
-def main(args=sys.argv):
+def main(args=sys.argv[1:]):
     args = parse_args(args)
     paths = {
         path


### PR DESCRIPTION
We should not pass sys.argv[0] to argparse, since it's the executables
filename. It will be deteced as the files attribute, which it should not be.