### PR TITLE
Prevent relint from capturing surrounding lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ If you prefer linting changed files (cached on git) you can use the option
 
 .. code-block:: bash
 
-    git diff | relint my_file.py --diff
+    git diff --unified=0 | relint my_file.py --diff
 
 This option is useful for pre-commit purposes. Here an example of how to use it
 with `pre-commit`_ framework:

--- a/relint-pre-commit.sh
+++ b/relint-pre-commit.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -eo pipefail
-git diff --staged | relint --diff -W "${@:1}"
+git diff --staged --unified=0 | relint --diff -W "${@:1}"


### PR DESCRIPTION
Relint sometimes report matches on unmodified lines, which surround the actually modified lines.

This can be fixed by overriding the `git diff` command that it executes under the hood. We only have to add `--unified=0` to tell `git diff` to not include any surrounding lines.