### PR TITLE
Fix #23 -- implement output message template format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ option `--diff [-d]` or `--git-diff [-g]`:
 git diff --unified=0 | relint my_file.py --diff
 ```
 
+### custom message format
+
+You can customize the output message format by using the `--msg-template=<format string>` option.
+The format string uses the [Python format syntax](https://docs.python.org/3/library/string.html#formatstrings) and the following fields are available:
+
+* filename
+
+    The name of the file being linted.
+
+* line_no
+
+    The line number of the match.
+
+* match
+
+    The matched text.
+
+* test.*
+
+  Any attribute of the test rule, e.g. `test.name` or `test.hint`.
+
+
 ### pre-commit
 
 You can automate the linting process by adding a

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ option `--diff [-d]` or `--git-diff [-g]`:
 git diff --unified=0 | relint my_file.py --diff
 ```
 
-### custom message format
+### Custom message format
 
-You can customize the output message format by using the `--msg-template=<format string>` option.
-The format string uses the [Python format syntax](https://docs.python.org/3/library/string.html#formatstrings) and the following fields are available:
+Customize the output message format with the `--msg-template=<format string>` option.
+[Python format syntax](https://docs.python.org/3/library/string.html#formatstrings)
+is suported for the message template and the following fields are available:
 
 * filename
 

--- a/relint/__main__.py
+++ b/relint/__main__.py
@@ -48,7 +48,7 @@ def parse_args(args):
         type=str,
         default="{filename}:{line_no} {test.name}\nHint: {test.hint}\n{match}",
         help="Template used to display messages. "
-        "Default: {filename}:{line_no} {test.name}\nHint: {test.hint}\n{match}",
+        r"Default: {filename}:{line_no} {test.name}\nHint: {test.hint}\n{match}",
     )
     return parser.parse_args(args=args)
 

--- a/relint/__main__.py
+++ b/relint/__main__.py
@@ -42,6 +42,14 @@ def parse_args(args):
     parser.add_argument(
         "-W", "--fail-warnings", action="store_true", help="Fail for warnings."
     )
+    parser.add_argument(
+        "--msg-template",
+        metavar="MSG_TEMPLATE",
+        type=str,
+        default="{filename}:{line_no} {test.name}\nHint: {test.hint}\n{match}",
+        help="Template used to display messages. "
+        "Default: {filename}:{line_no} {test.name}\nHint: {test.hint}\n{match}",
+    )
     return parser.parse_args(args=args)
 
 
@@ -73,7 +81,7 @@ def main(args=sys.argv[1:]):
         changed_content = parse_diff(output)
         matches = match_with_diff_changes(changed_content, matches)
 
-    exit_code = print_culprits(matches)
+    exit_code = print_culprits(matches, args.msg_template)
     exit(exit_code)
 
 

--- a/relint/parse.py
+++ b/relint/parse.py
@@ -82,7 +82,7 @@ def split_diff_content_by_filename(output: str) -> {str: str}:
     return content_by_filename
 
 
-def print_culprits(matches):
+def print_culprits(matches, msg_template):
     exit_code = 0
     _filename = ""
     lines = []
@@ -96,24 +96,23 @@ def print_culprits(matches):
 
         start_line_no = match.string[: match.start()].count("\n")
         end_line_no = match.string[: match.end()].count("\n")
-        output_format = "{filename}:{line_no} {test.name}"
-        print(
-            output_format.format(
-                filename=filename,
-                line_no=start_line_no + 1,
-                test=test,
-            )
-        )
-        if test.hint:
-            print("Hint:", test.hint)
         match_lines = (
             "{line_no}>    {code_line}".format(
                 line_no=no + start_line_no + 1,
-                code_line=line,
+                code_line=line.lstrip(),
             )
             for no, line in enumerate(lines[start_line_no : end_line_no + 1])
         )
-        print(*match_lines, sep="\n")
+        # special characters from shell are escaped
+        msg_template = msg_template.replace("\\n", "\n")
+        print(
+            msg_template.format(
+                filename=filename,
+                line_no=start_line_no + 1,
+                test=test,
+                match=chr(10).join(match_lines),
+            )
+        )
 
     return exit_code
 

--- a/tests/fixtures/.relint.yml
+++ b/tests/fixtures/.relint.yml
@@ -3,8 +3,3 @@
   hint: Get it done right away!
   filePattern: ^(?!.*test_).*\.(py|js)$
   error: false
-
-- name: Not Unicode
-  pattern: '[tT][oO][dD][oO]'
-  filePattern: .*
-  error: false

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,7 +36,7 @@ class TestMain:
 
         with tmpdir.as_cwd():
             with pytest.raises(SystemExit) as exc_info:
-                template = "😵{filename}:{line_no} | {test.name} \n {match}"
+                template = r"😵{filename}:{line_no} | {test.name} \n {match}"
                 main(["relint.py", "dummy.py", "--msg-template", template])
 
         expected_message = "😵dummy.py:1 | No ToDo \n" " 1>    # TODO do something\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,6 +28,23 @@ class TestMain:
 
         assert exc_info.value.code == 0
 
+    def test_main_execution_with_custom_template(self, capsys, tmpdir, fixture_dir):
+        with (fixture_dir / ".relint.yml").open() as fs:
+            config = fs.read()
+        tmpdir.join(".relint.yml").write(config)
+        tmpdir.join("dummy.py").write("# TODO do something")
+
+        with tmpdir.as_cwd():
+            with pytest.raises(SystemExit) as exc_info:
+                template = "😵{filename}:{line_no} | {test.name} \n {match}"
+                main(["relint.py", "dummy.py", "--msg-template", template])
+
+        expected_message = "😵dummy.py:1 | No ToDo \n" " 1>    # TODO do something\n"
+
+        out, _ = capsys.readouterr()
+        assert expected_message == out
+        assert exc_info.value.code == 0
+
     @pytest.mark.parametrize("filename", ["test_parse.py", "[a-b].py", "[b-a].py"])
     def test_raise_for_warnings(self, filename, tmpdir, fixture_dir):
         with (fixture_dir / ".relint.yml").open() as fs:


### PR DESCRIPTION
Inspired by pylint:
https://pylint.pycqa.org/en/latest/user_guide/usage/output.html#custom-message-formats


## Todo if accepted:
- [x] tests
- [x] documentation of all template options