### PR TITLE
Fix various texts in code and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Johannes Hoppe
+Copyright (c) 2018 Johannes Maron
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![PyPi Version](https://img.shields.io/pypi/v/relint.svg)](https://pypi.python.org/pypi/relint/)
 [![Test Coverage](https://codecov.io/gh/codingjoe/relint/branch/main/graph/badge.svg)](https://codecov.io/gh/codingjoe/relint)
-[![GitHub License](https://img.shields.io/github/license/codingjoe/relint)](https://raw.githubusercontent.com/codingjoe/relint/master/LICENSE)
+[![GitHub License](https://img.shields.io/github/license/codingjoe/relint)](https://raw.githubusercontent.com/codingjoe/relint/main/LICENSE)
 
 ## Installation
 
@@ -40,7 +40,7 @@ exit with a bad (non-zero) exit code. The default is `true`.
 
 The following command will lint all files in the current directory:
 
-```shell-session
+```shell
 relint -c .relint.yml **
 ```
 

--- a/relint/parse.py
+++ b/relint/parse.py
@@ -74,10 +74,10 @@ def split_diff_content_by_filename(output: str) -> {str: str}:
     """
     content_by_filename = {}
     filenames = parse_filenames(output)
-    splited_content = re.split(GIT_DIFF_SPLIT_PATTERN, output)
-    splited_content = filter(lambda x: x != "", splited_content)
+    split_content = re.split(GIT_DIFF_SPLIT_PATTERN, output)
+    split_content = filter(lambda x: x != "", split_content)
 
-    for filename, content in zip(filenames, splited_content):
+    for filename, content in zip(filenames, split_content):
         content_by_filename[filename] = content
     return content_by_filename
 

--- a/tests/fixtures/test.diff
+++ b/tests/fixtures/test.diff
@@ -3,14 +3,14 @@ index 43032c5..e7203b3 100644
 --- a/README.rst
 +++ b/README.rst
 @@ -51,7 +51,7 @@ If you prefer linting changed files (cached on git) you can use the option
- 
+
  .. code-block:: bash
- 
+
 -    relint my_file.py --diff
 +    git diff | relint my_file.py --diff
- 
+
  This option is useful for pre-commit purposes.
- 
+
 diff --git a/relint.py b/relint.py
 index 31061ec..697a3f0 100644
 --- a/relint.py
@@ -18,16 +18,16 @@ index 31061ec..697a3f0 100644
 @@ -113,7 +113,7 @@ def print_culprits(matches):
      for filename, test, match, _ in matches:
          exit_code = test.error if exit_code == 0 else exit_code
- 
+
 -        if filename != _filename:
 +        if filename != _filename:  # TODO check this out
              _filename = filename
              lines = match.string.splitlines()
- 
+
 @@ -167,7 +167,7 @@ def main():
          for path in paths
      )
- 
+
 -    if args.diff:
 +    if args.diff:  # TODO wow
          output = sys.stdin.read()
@@ -40,20 +40,20 @@ index 7165fd3..249b783 100644
 @@ -54,8 +54,9 @@ class TestParseGitDiff:
      def test_split_diff_content(self):
          output = open('test.diff').read()
-         splited = split_diff_content(output)
+         split = split_diff_content(output)
 +
-         assert isinstance(splited, dict)
--        assert len(splited) == 2
-+        assert len(splited) == 3
- 
+         assert isinstance(split, dict)
+-        assert len(split) == 2
++        assert len(split) == 3
+
      def test_return_empty_list_if_can_not_split_diff_content(self):
-         splited = split_diff_content('')
+         split = split_diff_content('')
 @@ -120,7 +121,7 @@ class TestParseGitDiff:
                  "@@ -1,0 +2 @@\n" \
                  "+# TODO: I'll do it later, promise\n"
- 
+
 -        parsed_content = parse_diff(output)
 +        parsed_content = parse_diff(output)  # TODO brand new
          expected = {'test_relint.py': [2]}
- 
+
          assert parsed_content == expected

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -41,14 +41,14 @@ class TestParseGitDiff:
     def test_split_diff_content(self, fixture_dir):
         with (fixture_dir / "test.diff").open() as fs:
             output = fs.read()
-        splited = split_diff_content_by_filename(output)
+        split = split_diff_content_by_filename(output)
 
-        assert isinstance(splited, dict)
-        assert len(splited) == 3
+        assert isinstance(split, dict)
+        assert len(split) == 3
 
     def test_return_empty_list_if_can_not_split_diff_content(self):
-        splited = split_diff_content_by_filename("")
-        assert splited == {}
+        split = split_diff_content_by_filename("")
+        assert split == {}
 
     def test_return_empty_dict_when_diff_returns_empty(self):
         parsed_content = parse_diff("")


### PR DESCRIPTION
For example, I replaced archaic "splited" in favor of "split".