### PR TITLE
Make sure we receive `int` exit code

### DIFF
--- a/tests/fixtures/.relint.yml
+++ b/tests/fixtures/.relint.yml
@@ -3,3 +3,9 @@
   hint: Get it done right away!
   filePattern: ^(?!.*test_).*\.(py|js)$
   error: false
+
+- name: No fixme (warning)
+  pattern: '[fF][iI][xX][mM][eE]'
+  hint: Fix it right away!
+  filePattern: ^(?!.*test_).*\.(py|js)$
+  error: true


### PR DESCRIPTION
- added a missing test case for an error
- fixed tests to not try to use non-existent files, which was leading to `SystemExit(2) unrecognized arguments python`
- made strict exit_code == 1 assertion
