### PR TITLE
Add `--ignore-warnings` argument

### DIFF
--- a/relint/__main__.py
+++ b/relint/__main__.py
@@ -43,6 +43,9 @@ def parse_args(args=None):
         "-W", "--fail-warnings", action="store_true", help="Fail for warnings."
     )
     parser.add_argument(
+        "--ignore-warnings", action="store_true", help="Ignore warnings."
+    )
+    parser.add_argument(
         "--msg-template",
         metavar="MSG_TEMPLATE",
         type=str,
@@ -66,7 +69,7 @@ def main(args=None):
         for path in glob.iglob(glob.escape(file), recursive=True)
     }
 
-    tests = list(load_config(args.config, args.fail_warnings))
+    tests = list(load_config(args.config, args.fail_warnings, args.ignore_warnings))
 
     matches = chain.from_iterable(lint_file(path, tests) for path in paths)
 

--- a/relint/config.py
+++ b/relint/config.py
@@ -18,10 +18,13 @@ Test = collections.namedtuple(
 )
 
 
-def load_config(path, fail_warnings):
+def load_config(path, fail_warnings, ignore_warnings):
     with open(path) as fs:
         try:
             for test in yaml.safe_load(fs):
+                if ignore_warnings and not test.get("error", True):
+                    continue
+
                 file_pattern = test.get("filePattern", ".*")
                 file_pattern = re.compile(file_pattern)
                 yield Test(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -71,6 +71,17 @@ class TestMain:
 
         assert exc_info.value.code == 1
 
+    def test_ignore_warnings(self, tmpdir, fixture_dir):
+        with (fixture_dir / ".relint.yml").open() as fs:
+            config = fs.read()
+        tmpdir.join(".relint.yml").write(config)
+        tmpdir.join("dummy.py").write("# TODO do something")
+        with tmpdir.as_cwd():
+            with pytest.raises(SystemExit) as exc_info:
+                main(["relint.py", "dummy.py", "--ignore-warnings"])
+
+        assert exc_info.value.code == 0
+
     def test_main_execution_with_diff(self, capsys, mocker, tmpdir, fixture_dir):
         with (fixture_dir / ".relint.yml").open() as fs:
             config = fs.read()


### PR DESCRIPTION
In my usecase, I want to show warnings to the developer (via pre-commit), but don't want to output them in CI. Here such setting would be handy.


P.S. I am basing this PR on top of #45 as it has fixed tests suite, which is needed here.