### PR TITLE
Use CI linters in pre-commit

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-exclude: tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  - repo: local
+    hooks:
+      - id: relint
+        name: reLint
+        description: 'Write your own linting rules using regular expressions.'
+        entry: relint
+        args: ["--fail-warnings", "--git-diff"]
+        language: python
+        types: [file]
+
+      - id: bandit
+        name: bandit
+        description: 'Security linter for Python code.'
+        entry: bandit
+        args: ["--configfile", "pyproject.toml"]
+        language: python
+
+      - id: black
+        name: black
+        entry: black
+        description: 'The uncompromising Python code formatter.'
+        args: ["--check", ".", "--diff"]
+        language: python
+        types: [python]
+
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: python
+        types: [python]
+
+      - id: isort
+        name: isort
+        entry: isort
+        args: ["--check-only", "--diff"]
+        language: python
+        types: [python]
+
+      - id: pydocstyle
+        name: pydocstyle
+        entry: pydocstyle
+        language: python
+        types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,0 @@
--   id: relint
-    name: relint
-    description: 'Write your own linting rules using regular expressions.'
-    entry: relint
-    args: [--git-diff]
-    language: python
-    types: [file]

--- a/linter-requirements.txt
+++ b/linter-requirements.txt
@@ -1,4 +1,4 @@
-bandit==1.7.4
+bandit[toml]==1.7.4
 black==23.1.0
 flake8==6.0.0
 isort==5.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,7 @@ combine_as_imports = true
 
 [tool.pydocstyle]
 add_ignore = "D1"
+
+[tool.bandit]
+exclude_dirs = ["*/tests/*",]
+skips = ["B101",]


### PR DESCRIPTION
I noticed that we have pre-commit installed, also a bunch of linters running in CI.
However, I had no pre-commit running locally (wrong pre-commit config file), also there were no checks defined.
