### PR TITLE
Add rich to enrich output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 requires-python = ">=3.8"
-dependencies = ["PyYAML"]
+dependencies = [
+  "PyYAML",
+  "rich",
+]
 
 [project.optional-dependencies]
 test = [

--- a/tests/fixtures/.relint.yml
+++ b/tests/fixtures/.relint.yml
@@ -6,6 +6,28 @@
 
 - name: No fixme (warning)
   pattern: '[fF][iI][xX][mM][eE]'
-  hint: Fix it right away!
+  hint: |
+    ### This is a multiline hint
+    Fix it right away!
+
+    You can use code blocks too, like Python:
+
+    ```python
+    print('hello world')
+    ```
+
+    Or JavaScript:
+
+    ```javascript
+    console.log('hello world')
+    ```
+
+    And even Git diffs:
+
+    ```diff
+    - print('hello world')
+    + console.log('hello world')
+    ```
+
   filePattern: ^(?!.*test_).*\.(py|js)$
   error: true


### PR DESCRIPTION
### Notable Changes

* Enable Markdown support to hints
* Add code highlighting
* Colorize errors and warnings differently
* Drop the obsolete `--msg-template` argument
* Add a `--code-padding` argument to adjust code snippets
* Add a `--summarize` argument to matches by test
* Add progress bar

### Example

<img width="689" alt="Screenshot 2023-03-08 at 14 39 42" src="https://user-images.githubusercontent.com/1772890/223728373-d9d965f9-bf92-42d6-9626-ce2297a2d946.png">


