### PR TITLE
fix: support git diff mnemonic prefixes (#133)

### DIFF
--- a/relint/parse.py
+++ b/relint/parse.py
@@ -14,7 +14,9 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 
 GIT_DIFF_LINE_NUMBERS_PATTERN = re.compile(r"@ -\d+(,\d+)? \+(\d+)(,)?(\d+)? @")
-GIT_DIFF_FILENAME_PATTERN = re.compile(r"(?:\n|^)diff --git [^\/]+\/.* [^\/]+\/(.*)(?:\n|$)")
+GIT_DIFF_FILENAME_PATTERN = re.compile(
+    r"(?:\n|^)diff --git [^\/]+\/.* [^\/]+\/(.*)(?:\n|$)"
+)
 GIT_DIFF_SPLIT_PATTERN = re.compile(r"(?:\n|^)diff --git [^\/]+\/.* [^\/]+\/.*(?:\n|$)")
 
 

--- a/relint/parse.py
+++ b/relint/parse.py
@@ -14,8 +14,8 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 
 GIT_DIFF_LINE_NUMBERS_PATTERN = re.compile(r"@ -\d+(,\d+)? \+(\d+)(,)?(\d+)? @")
-GIT_DIFF_FILENAME_PATTERN = re.compile(r"(?:\n|^)diff --git a\/.* b\/(.*)(?:\n|$)")
-GIT_DIFF_SPLIT_PATTERN = re.compile(r"(?:\n|^)diff --git a\/.* b\/.*(?:\n|$)")
+GIT_DIFF_FILENAME_PATTERN = re.compile(r"(?:\n|^)diff --git [^\/]+\/.* [^\/]+\/(.*)(?:\n|$)")
+GIT_DIFF_SPLIT_PATTERN = re.compile(r"(?:\n|^)diff --git [^\/]+\/.* [^\/]+\/.*(?:\n|$)")
 
 
 def lint_file(filename, tests):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -122,7 +122,6 @@ class TestParseGitDiff:
 
         assert parsed_content == expected
 
-
     def test_parse_diff_with_mnemonic_prefixes(self):
         output = (
             "diff --git c/sql/very-important-sql.sql i/sql/very-important-sql.sql\n"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -34,6 +34,10 @@ class TestParseGitDiff:
                 "diff --git a/pardal/authserver/app.py b/pardal/authserver/app.py",
                 "pardal/authserver/app.py",
             ),
+            (
+                "diff --git c/sql/very-important-sql.sql i/sql/very-important-sql.sql",
+                "sql/very-important-sql.sql",
+            ),
         ],
     )
     def test_parse_filenames(self, output, expected_filename):
@@ -115,6 +119,23 @@ class TestParseGitDiff:
 
         parsed_content = parse_diff(output)
         expected = {"test_parse.py": [2]}
+
+        assert parsed_content == expected
+
+
+    def test_parse_diff_with_mnemonic_prefixes(self):
+        output = (
+            "diff --git c/sql/very-important-sql.sql i/sql/very-important-sql.sql\n"
+            "index 9c7f392..9bde2ad 100644\n"
+            "--- c/sql/very-important-sql.sql\n"
+            "+++ i/sql/very-important-sql.sql\n"
+            "@@ -1 +1 @@\n"
+            "-select 1;\n"
+            "+select 2;\n"
+        )
+
+        parsed_content = parse_diff(output)
+        expected = {"sql/very-important-sql.sql": [1]}
 
         assert parsed_content == expected
 


### PR DESCRIPTION
Closes #133

## Summary

`git diff` can use mnemonic prefixes when `diff.mnemonicPrefix=true`, for example:

```diff
diff --git c/sql/very-important-sql.sql i/sql/very-important-sql.sql
```

`relint` currently only recognizes `a/` and `b/` prefixes in `diff --git` headers. With mnemonic prefixes, `parse_filenames()` returns no filenames while the diff content is still split, which makes `zip(..., strict=True)` raise `ValueError`.

This updates the diff header regexes to accept any one-component git prefix before the slash, while preserving the captured destination filename.

## Verification

- Added coverage for parsing mnemonic-prefix diff headers.
- Ran `pytest tests/test_parse.py -q`: 19 passed.
